### PR TITLE
Adapt to use local user auth

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/concourse/atc"
+	"github.com/concourse/concourse/atc"
 )
 
 type GithubWebhookHandler struct {
@@ -37,7 +37,7 @@ func (gh *GithubWebhookHandler) ServeHTTP(rw http.ResponseWriter, req *http.Requ
 	log.Printf("Received webhhook for %s", pushEvent.Repository.CloneURL)
 
 	ScanResourceCache(func(pipeline Pipeline, resource atc.ResourceConfig) bool {
-		if resource.Type != "git" {
+		if resource.Type != "git" && resource.Type != "pull-request" {
 			return true
 		}
 		if uri, ok := resource.Source["uri"].(string); ok {

--- a/resource_cache.go
+++ b/resource_cache.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"sync"
 
-	"github.com/concourse/atc"
-	"github.com/concourse/go-concourse/concourse"
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/go-concourse/concourse"
 )
 
 type Pipeline struct {


### PR DESCRIPTION
Basic auth was replaced with the concept of a "local user" in Concourse
v4.0.0. This is an update to the webhook broadcaster to use a local user
instead of a set of basic auth credentials.