### PR TITLE
Fix oauth token refresh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PKG:=github.com/sapcc/webhook-broadcaster
 IMAGE:=sapcc/concourse-webhook-broadcaster
-VERSION:=0.6.1
+VERSION:=0.6.2
 build:
 	go build -v -o bin/webhook-broadcaster $(PKG)
 

--- a/concourse.go
+++ b/concourse.go
@@ -10,22 +10,32 @@ import (
 	"golang.org/x/oauth2"
 )
 
-/* NewHttpClient creates an HTTP client that can refresh its oauth2 AccessToken */
-func NewHttpClient(concourseURL string, username string, password string) (*http.Client, error) {
+type client struct {
+	concourseURL string
+	oauth2Config *oauth2.Config
+	token        *oauth2.Token
+	ctx          context.Context
+}
+
+func NewConcourseClient(concourseURL string, username string, password string) (*client, error) {
+	c := client{
+		concourseURL: concourseURL,
+	}
+
 	tokenEndPoint, err := url.Parse("sky/token")
 	if err != nil {
-		return nil, err
+		return &client{}, err
 	}
 
 	base, err := url.Parse(concourseURL)
 	if err != nil {
-		return nil, err
+		return &client{}, err
 	}
 
 	tokenURL := base.ResolveReference(tokenEndPoint)
 
 	/* We leverage the fact that `fly` is considered a "public client" to fetch our oauth token */
-	oauth2Config := oauth2.Config{
+	c.oauth2Config = &oauth2.Config{
 		ClientID:     "fly",
 		ClientSecret: "Zmx5",
 		Endpoint:     oauth2.Endpoint{TokenURL: tokenURL.String()},
@@ -33,24 +43,19 @@ func NewHttpClient(concourseURL string, username string, password string) (*http
 	}
 
 	httpClient := &http.Client{Timeout: 2 * time.Second}
-	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, &httpClient)
+	c.ctx = context.WithValue(context.Background(), oauth2.HTTPClient, &httpClient)
 
-	token, err := oauth2Config.PasswordCredentialsToken(ctx, username, password)
+	c.token, err = c.oauth2Config.PasswordCredentialsToken(c.ctx, username, password)
 	if err != nil {
-		return nil, err
+		return &client{}, err
 	}
 
-	return oauth2Config.Client(ctx, token), nil
+	return &c, nil
 }
 
-/* NewConcourseClient creates a Concourse client */
-func NewConcourseClient(concourseURL string, username string, password string) (*concourse.Client, error) {
-	httpClient, err := NewHttpClient(concourseURL, username, password)
-	if err != nil {
-		return nil, err
-	}
+func (c *client) RefreshClientWithToken() (concourse.Client, error) {
+	httpClient := c.oauth2Config.Client(c.ctx, c.token)
+	concourseClient := concourse.NewClient(c.concourseURL, httpClient, false)
 
-	client := concourse.NewClient(concourseURL, httpClient, false)
-
-	return &client, nil
+	return concourseClient, nil
 }

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 		log.Fatal("Missing one or more of required flags: -concourse-url -auth-user -auth-password")
 	}
 
-	concourseClient, err := NewConcourseClient(concourseURL, authUser, authPassword)
+	client, err := NewConcourseClient(concourseURL, authUser, authPassword)
 	if err != nil {
 		log.Fatalf("Failed to create Concourse client")
 	}
@@ -80,7 +80,7 @@ func main() {
 		tick := time.NewTicker(refreshInterval)
 		defer tick.Stop()
 		for {
-			UpdateCache(*concourseClient)
+			UpdateCache(*client)
 			select {
 			case <-tick.C:
 			case <-cancelCache:


### PR DESCRIPTION
This PR fixes oauth token refresh. Currently token is expiring after a certain amount of time and webhook-broadcaster is not able to speak to concourse anymore. Call of `c.oauth2Config.Client()` is refreshing token if necessary.