### PR TITLE
Remove deprecated return value from PipelineConfig call.

### DIFF
--- a/resource_cache.go
+++ b/resource_cache.go
@@ -50,7 +50,7 @@ func UpdateCache(cclient client) error {
 			//temporarly memorize pipelines from team to cleanup after the teams loop
 			pipelinesByID[pipeline.ID] = pipeline
 
-			config, _, version, found, err := client.PipelineConfig(pipeline.Name)
+			config, version, found, err := client.PipelineConfig(pipeline.Name)
 			if err != nil {
 				log.Printf("Failed to get pipeline %s/%s: %s", pipeline.TeamName, pipeline.Name, err)
 				continue


### PR DESCRIPTION
Concourse PipelineConfig in Team interface has changed from five to four return values.
https://github.com/concourse/concourse/blob/a7403f63c50655f9f758384e9bd007b40372524c/go-concourse/concourse/team.go#L28
This pull request removes the return value which was being ignored anyway.