### PR TITLE
Add support for GitHub PR Resource

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -40,7 +40,7 @@ func (gh *GithubWebhookHandler) ServeHTTP(rw http.ResponseWriter, req *http.Requ
 		if resource.Type != "git" && resource.Type != "pull-request" && resource.Type != "git-proxy" {
 			return true
 		}
-		if uri, ok := resource.Source["uri"].(string); ok {
+		if uri, ok := ConstructGitHubUriFromConfig(resource); ok {
 			if SameGitRepository(uri, pushEvent.Repository.CloneURL) {
 				webhookURL := fmt.Sprintf("%s/api/v1/teams/%s/pipelines/%s/resources/%s/check/webhook?webhook_token=%s",
 					concourseURL,

--- a/resource_parser.go
+++ b/resource_parser.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/concourse/concourse/atc"
+)
+
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}
+
+// The various GitHub-related resource types store their repository
+// configuration in different ways. This function handles the different
+// approaches and returns a standardised repository URL.
+func ConstructGitHubUriFromConfig(resource atc.ResourceConfig) (string, bool) {
+	keys := make([]string, 0, len(resource.Source))
+	for k := range resource.Source {
+		keys = append(keys, k)
+	}
+
+	// Config in `uri` key for:
+	// - concourse/git-resource
+	if contains(keys, "uri") {
+		return resource.Source["uri"].(string), true
+	}
+
+	// Config in `repository` key only for:
+	// - telia-oss/github-pr-resource
+	if contains(keys, "repository") {
+		return fmt.Sprintf("https://github.com/%s", resource.Source["repository"].(string)), true
+	}
+
+	return "", false
+}

--- a/resource_parser_test.go
+++ b/resource_parser_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/concourse/concourse/atc"
+)
+
+func TestGitHubUriConstruction(t *testing.T) {
+	cases := []struct {
+		ResourceConfig atc.ResourceConfig
+		Result         string
+	}{
+		{atc.ResourceConfig{Source: atc.Source{"uri": "https://github.com/some/repo"}}, "https://github.com/some/repo"},
+		{atc.ResourceConfig{Source: atc.Source{"repository": "some/repo"}}, "https://github.com/some/repo"},
+	}
+
+	for nr, c := range cases {
+		uri, ok := ConstructGitHubUriFromConfig(c.ResourceConfig)
+		if !ok || uri != c.Result {
+			t.Errorf("Test case %d failed.", nr+1)
+		}
+	}
+}


### PR DESCRIPTION
This PR adds support in the webhook broadcaster for the [telia-oss/github-pr-resource](https://github.com/telia-oss/github-pr-resource).

This resource differs from [concourse/git-resource](https://github.com/concourse/git-resource) as it does not have a `uri` key in its source config referring to the relevant GitHub repository. To resolve this issue, I have introduced a new function which can check for the alternative `repository` key in the resource's source config.

Happy to answer any questions or fix any issues you find with this PR. Thanks for maintaining this project to date. It has been very helpful for us!