### PR TITLE
Add support for custom Git resource types

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,21 @@ Usage
 2. Create a github webhook for push events pointing it to `http://webhook-broadcaster.somewhere:8080/github`
 3. Make sure resources of type `git` have a `webhook_token` configured
 
+Configurability
+===============
+The webhook-broadcaster natively supports resource types `git`, `git-proxy` and `pull-request`. As resource type names are purely conventional (except for a few core types) and new resource types can be declared in Concourse pipelines using a `resource_types` block, your environment may have additional types. In addition, different resource implementations use different config attributes to identify which Git repository they operate on. The core resource types all use `uri` to hold the full URI. Other popular resource types use other attributes, often in combination (e.g. `repository` on `org/repo` form, or split up into `owner` and `repository`).
+
+Use the `--add-resource-uri-pattern=<name>:<pattern>` option to register a new type-name and uri-pattern combination with webhook-broadcaster. It can be specified multiple times. For example:
+
+```
+--add-resource-uri-pattern=pull-request:https://github.com/{repository} \
+--add-resource-uri-pattern=pull-request:https://private-repo.local/{repository} \
+--add-resource-uri-pattern=gh-release:https://private-repo.local/{owner}/{repository}
+...
+```
+
+The `{placeholder}` tokens for the matching resource type name are expanded directly from the resource `source:` map defined in the pipeline. When scanning resources, the broadcaster will try to match all expansions for the resource type against the push-event repository URL, in the order they're defined on the command line. If multiple pattern should match, only the first match will be considered.
+
 Compatibility
 =============
 * webhook-broadcaster should work with concourse `>=4.x`. There is a branch https://github.com/sapcc/webhook-broadcaster/tree/concourse-3.x that supports concourse `3.x`.

--- a/handlers.go
+++ b/handlers.go
@@ -13,7 +13,8 @@ import (
 )
 
 type GithubWebhookHandler struct {
-	queue *RequestWorkqueue
+	queue               *RequestWorkqueue
+	resourceURIPatterns map[string][]string
 }
 
 func (gh *GithubWebhookHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
@@ -64,59 +65,72 @@ func (gh *GithubWebhookHandler) ServeHTTP(rw http.ResponseWriter, req *http.Requ
 	}
 
 	ScanResourceCache(func(pipeline Pipeline, resource atc.ResourceConfig) bool {
-		if resource.Type != "git" && resource.Type != "pull-request" && resource.Type != "git-proxy" {
-			return true
-		}
-		if uri, ok := resource.Source["uri"].(string); ok {
-			if SameGitRepository(uri, pushEvent.Repository.CloneURL) {
-				if resource.Type == "git" || resource.Type == "git-proxy" {
-					//skip, if push is for branch not tracked by resource
-					branch, _ := resource.Source["branch"].(string)
-					if branch == "" {
-						branch = pushEvent.Repository.DefaultBranch
-					}
-					if strings.TrimPrefix(pushEvent.Ref, "refs/heads/") != branch {
-						log.Printf("Skipping resource %s/%s in team %s. Which is tracking branch %s", pipeline.Name, resource.Name, pipeline.Team, branch)
-						return true
-					}
-				}
+		if uri, ok := gh.matchResourceURI(resource, pushEvent.Repository.CloneURL); ok {
+			debugf("%s/%s(%s): matched resource uri %s to %s", pipeline.Name, resource.Name, resource.Type, uri, pushEvent.Repository.CloneURL)
 
-				//skip if path filter of resource does not match any of the changed files
-				if ps, ok := resource.Source["paths"].([]interface{}); ok && len(ps) > 0 {
-					paths := make([]string, 0, len(ps))
-					for _, p := range ps {
-						if pstring, ok := p.(string); ok {
-							paths = append(paths, pstring)
-						}
-					}
-					if len(paths) > 0 && !matchFiles(paths, filesChanged) {
-						log.Printf("Skipping resource %s/%s in team %s, due to path filter", pipeline.Name, resource.Name, pipeline.Team)
-						return true
-					}
-					debugf("resource %s/%s has matching path filter: %#v", pipeline.Name, resource.Name, resource.Source)
-				} else {
-					debugf("resource %s/%s has no path filter: %#v", pipeline.Name, resource.Name, resource.Source)
+			if resource.Type == "git" || resource.Type == "git-proxy" {
+				//skip, if push is for branch not tracked by resource
+				branch, _ := resource.Source["branch"].(string)
+				if branch == "" {
+					branch = pushEvent.Repository.DefaultBranch
 				}
-				queryParams := url.Values{}
-				for key, vals := range pipeline.QueryParams {
-					for _, val := range vals {
-						queryParams.Add(key, val)
-					}
+				if strings.TrimPrefix(pushEvent.Ref, "refs/heads/") != branch {
+					log.Printf("Skipping resource %s/%s in team %s. Which is tracking branch %s", pipeline.Name, resource.Name, pipeline.Team, branch)
+					return true
 				}
-				queryParams.Set("webhook_token", resource.WebhookToken)
-				webhookURL := fmt.Sprintf("%s/api/v1/teams/%s/pipelines/%s/resources/%s/check/webhook?%s",
-					concourseURL,
-					pipeline.Team,
-					pipeline.Name,
-					resource.Name,
-					queryParams.Encode(),
-				)
-				gh.queue.Add(webhookURL)
 			}
+
+			//skip if path filter of resource does not match any of the changed files
+			if ps, ok := resource.Source["paths"].([]interface{}); ok && len(ps) > 0 {
+				paths := make([]string, 0, len(ps))
+				for _, p := range ps {
+					if pstring, ok := p.(string); ok {
+						paths = append(paths, pstring)
+					}
+				}
+				if len(paths) > 0 && !matchFiles(paths, filesChanged) {
+					log.Printf("Skipping resource %s/%s in team %s, due to path filter", pipeline.Name, resource.Name, pipeline.Team)
+					return true
+				}
+				debugf("resource %s/%s has matching path filter: %#v", pipeline.Name, resource.Name, resource.Source)
+			} else {
+				debugf("resource %s/%s has no path filter: %#v", pipeline.Name, resource.Name, resource.Source)
+			}
+			queryParams := url.Values{}
+			for key, vals := range pipeline.QueryParams {
+				for _, val := range vals {
+					queryParams.Add(key, val)
+				}
+			}
+			queryParams.Set("webhook_token", resource.WebhookToken)
+			webhookURL := fmt.Sprintf("%s/api/v1/teams/%s/pipelines/%s/resources/%s/check/webhook?%s",
+				concourseURL,
+				pipeline.Team,
+				pipeline.Name,
+				resource.Name,
+				queryParams.Encode(),
+			)
+			gh.queue.Add(webhookURL)
 		}
 		return true
 	})
 
+}
+
+func (gh *GithubWebhookHandler) matchResourceURI(resource atc.ResourceConfig, repoCloneURL string) (string, bool) {
+	patterns, ok := gh.resourceURIPatterns[resource.Type]
+	if !ok {
+		// Unsupported resource type
+		return "", false
+	}
+	for _, pattern := range patterns {
+		if uri, ok := ExpandPattern(pattern, resource.Source); ok {
+			if SameGitRepository(uri, repoCloneURL) {
+				return uri, true
+			}
+		}
+	}
+	return "", false
 }
 
 func matchFiles(patterns []string, files []string) bool {

--- a/main.go
+++ b/main.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -23,16 +25,46 @@ type resource struct {
 	token    string
 }
 
+// flag.Value for "type:pattern" multi-options
+type resourcePatternsValue map[string][]string
+
+func (rp *resourcePatternsValue) String() string {
+	var specs []string
+	for resourceType, patterns := range *rp {
+		for _, pattern := range patterns {
+			specs = append(specs, fmt.Sprintf("%s:%s", resourceType, pattern))
+		}
+	}
+	return strings.Join(specs, ", ")
+}
+
+func (rp *resourcePatternsValue) Set(value string) error {
+	parts := strings.SplitN(value, ":", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid resource-type:pattern format: %s", value)
+	}
+
+	resourceType := parts[0]
+	pattern := parts[1]
+	(*rp)[resourceType] = append((*rp)[resourceType], pattern)
+	return nil
+}
+
 var (
-	listenAddr         string
-	concourseURL       string
-	authUser           string
-	authPassword       string
-	refreshInterval    time.Duration
-	webhookConcurrency int
-	flags              *flag.FlagSet
-	debug              bool
-	printVersion       bool
+	listenAddr          string
+	concourseURL        string
+	authUser            string
+	authPassword        string
+	refreshInterval     time.Duration
+	webhookConcurrency  int
+	flags               *flag.FlagSet
+	debug               bool
+	printVersion        bool
+	resourceURIPatterns = resourcePatternsValue{
+		"git":          {"{uri}"},
+		"git-proxy":    {"{uri}"},
+		"pull-request": {"{uri}"},
+	}
 )
 
 func init() {
@@ -46,6 +78,7 @@ func init() {
 	flags.IntVar(&webhookConcurrency, "webhook-concurrency", 20, "How many resources to notify in parallel")
 	flags.BoolVar(&debug, "dry-run", false, "Dry-run. Don't call webhooks")
 	flags.BoolVar(&printVersion, "version", false, "Print version info")
+	flags.Var(&resourceURIPatterns, "add-resource-uri-pattern", "Add new resource type and associated URI pattern, e.g. 'pull-request:http://github.com/{owner}/{repo}'")
 }
 
 func main() {
@@ -59,6 +92,8 @@ func main() {
 	if concourseURL == "" || authUser == "" || authPassword == "" {
 		log.Fatal("Missing one or more of required flags: -concourse-url -auth-user -auth-password")
 	}
+
+	log.Printf("Registered resource-types/uri-patterns: %s", &resourceURIPatterns)
 
 	client, err := NewConcourseClient(concourseURL, authUser, authPassword)
 	if err != nil {
@@ -132,7 +167,10 @@ func main() {
 			[]string{"code", "method"},
 		)
 		prometheus.Register(requestCounter)
-		ghHandler := promhttp.InstrumentHandlerCounter(requestCounter, &GithubWebhookHandler{requestQueue})
+		ghHandler := promhttp.InstrumentHandlerCounter(requestCounter, &GithubWebhookHandler{
+			requestQueue,
+			resourceURIPatterns,
+		})
 		mux.Handle("/github", ghHandler)
 		mux.Handle("/metrics", promhttp.Handler())
 		return http.Serve(ln, mux)

--- a/patterns.go
+++ b/patterns.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/concourse/concourse/atc"
+)
+
+var (
+	placeholderRegex = regexp.MustCompile(`{([^}]+)}`)
+)
+
+// ExpandPattern tries to expand a pattern with curly-braced placeholders using
+// a map for replacements. For example:
+//
+//	ExpandPattern("{a}-{b}", atc.Source{"a": "foo", "b": "bar", "c": "baz"})
+//
+// expands to "foo-bar". ExpandPattern returns true only if all placeholders
+// were expanded.
+func ExpandPattern(pattern string, attrs atc.Source) (string, bool) {
+	// Expand all {placeholder} patterns using data from resource config.
+	expanded := placeholderRegex.ReplaceAllStringFunc(pattern, func(placeholder string) string {
+		key := strings.Trim(placeholder, "{}")
+		// Only replace string values
+		if val, ok := attrs[key].(string); ok {
+			return val
+		}
+		// Return the placeholder itself if we can't find replacement.
+		return placeholder
+	})
+	if strings.ContainsAny(expanded, "{}") {
+		// Not fully expanded, signal failure
+		return "", false
+	}
+	return expanded, true
+}

--- a/patterns_test.go
+++ b/patterns_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/concourse/concourse/atc"
+)
+
+func TestExpand(t *testing.T) {
+	cases := []struct {
+		name        string
+		pattern     string
+		attrs       atc.Source
+		expectedVal string
+		expectedOK  bool
+	}{
+		{
+			// Expansion fails if one attr is missing
+			name:        "missing attr value",
+			pattern:     "https://g.com/{owner}/{repo}",
+			attrs:       atc.Source{"owner": "john"},
+			expectedVal: "",
+			expectedOK:  false,
+		},
+		{
+			// Expansion fails if we try to substitute non-string values
+			name:        "non-string attr values",
+			pattern:     "https://g.com/{org}/{repo}",
+			attrs:       atc.Source{"org": []string{"bob"}, "repo": 400},
+			expectedVal: "",
+			expectedOK:  false,
+		},
+		{
+			name:        "simple-https-uri",
+			pattern:     "https://github.com/{owner}/{repo}",
+			attrs:       atc.Source{"owner": "john", "repo": "doe"},
+			expectedVal: "https://github.com/john/doe",
+			expectedOK:  true,
+		},
+		{
+			name:        "simple-git-uri",
+			pattern:     "git@git.foo:{repo}",
+			attrs:       atc.Source{"repo": "jane/doe.git"},
+			expectedVal: "git@git.foo:jane/doe.git",
+			expectedOK:  true,
+		},
+		{
+			name:        "simple-branch-name",
+			pattern:     "{branch}",
+			attrs:       atc.Source{"branch": "master"},
+			expectedVal: "master",
+			expectedOK:  true,
+		},
+	}
+
+	for _, c := range cases {
+		actual, ok := ExpandPattern(c.pattern, c.attrs)
+		if ok != c.expectedOK || actual != c.expectedVal {
+			t.Errorf("%s: expected %q,%v, was %q,%v.", c.name, c.expectedVal, c.expectedOK, actual, ok)
+		}
+	}
+}


### PR DESCRIPTION
Resource types in Concourse, except the built-in 'git' type, are mostly type aliases. Users can name them whatever they want, provided they declare them pointing to a resource Docker image. Rather than hard-code which type names are handled by the resource scan loop, make it table-driven.

Since different resource type implementations use different attributes to denote the target Git repository, generalize so that users can register type names and URI patterns on the command-line.

The new -add-resource-uri-pattern option lets users register custom type names, and the associated pattern to build a Git repository URI from the resource attributes.

Every resource is now evaluated against all patterns registered for the type name to produce an URI, and if any of them match the push event, the resource will be further evaluated (branch filter, path filter).

Describe the pattern language in the README.

Baseline behavior should be the same after this patch, the mechanics are just more general.